### PR TITLE
Add "resolutions" in package.json to Fix sharp Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "stylelint-config-standard": "^20.0.0",
     "write-good": "^1.0.2"
   },
+  "resolutions": {
+    "sharp": "^0.24.1"
+  },
   "keywords": [
     "duncan leung",
     "front end",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12932,22 +12932,7 @@ shallowequal@^1.0.1, shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-sharp@^0.23.4:
-  version "0.23.4"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.23.4.tgz#ca36067cb6ff7067fa6c77b01651cb9a890f8eb3"
-  integrity sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==
-  dependencies:
-    color "^3.1.2"
-    detect-libc "^1.0.3"
-    nan "^2.14.0"
-    npmlog "^4.1.2"
-    prebuild-install "^5.3.3"
-    semver "^6.3.0"
-    simple-get "^3.1.0"
-    tar "^5.0.5"
-    tunnel-agent "^0.6.0"
-
-sharp@^0.24.1:
+sharp@^0.23.4, sharp@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.24.1.tgz#f853f9f495dfde05d452179b4f9f31dfc400f4ca"
   integrity sha512-1Lph6o7D6bU8WrcbG/kT7cVzi2UBi2xrrBfS/WUaD+ZcGd4MZ7+LbtFoGwbMVJH95d5aziBGyExYF4Urm2pjOQ==
@@ -14143,18 +14128,6 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
-
-tar@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-5.0.5.tgz#03fcdb7105bc8ea3ce6c86642b9c942495b04f93"
-  integrity sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==
-  dependencies:
-    chownr "^1.1.3"
-    fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.0"
-    mkdirp "^0.5.0"
-    yallist "^4.0.0"
 
 tar@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Fixes a build issue:

```
Something went wrong installing the "sharp" module

The specified procedure could not be found.
\\?\E:\workspace\taniarascia.com\node_modules\gatsby-plugin-manifest\node_modules\sharp\build\Release\sharp.node

- Remove the "node_modules/sharp" directory, run "npm install" and look for errors
- Consult the installation documentation at https://sharp.pixelplumbing.com/en/stable/install/
- Search for this error at https://github.com/lovell/sharp/issues


⠋ load plugins
error Command failed with exit code 1.
```

See https://github.com/gatsbyjs/gatsby/issues/21032

gatsby-plugin-manifest depends on sharp; in order to override this dependency, one has to use yarn resolutions.

Gatsby does not yet support the latest version of sharp because Gatsby requires Node 8, whereas Sharp requires Node 10. However, Sharp was recently updated for both Node 13 and libvips.

```
$ yarn why sharp
```
```
❯ yarn why sharp
yarn why v1.21.1
[1/4] 🤔  Why do we have the module "sharp"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "sharp@0.24.1"
info Reasons this module exists
   - "gatsby-plugin-manifest" depends on it
   - Hoisted from "gatsby-plugin-manifest#sharp"
   - Hoisted from "gatsby-plugin-sharp#sharp"
   - Hoisted from "gatsby-transformer-sharp#sharp"
info Disk size without dependencies: "6.69MB"
info Disk size with unique dependencies: "9.04MB"
info Disk size with transitive dependencies: "12.17MB"
info Number of shared dependencies: 50
```

"sharp": "^0.23.4" is in the package.json for gatsby-plugin-manifest.

It doesn't matter what version of sharp you have in the top-level dependency list. The only way you can get around this is to use a yarn `resolution` to override the version of sharp the Gatsby plugins use.