### PR TITLE
Replace deprecated 'wait' with 'waitFor'

### DIFF
--- a/content/posts/2020-02-18-testing-react-helmet-document-head-meta-tag-react-testing-library.md
+++ b/content/posts/2020-02-18-testing-react-helmet-document-head-meta-tag-react-testing-library.md
@@ -23,7 +23,7 @@ It's still possible to use the Browser API `document.getElementsByTagName("meta"
 ```tsx{7-17,26-30,37}
 import React from "react";
 import { render } from "test-utils";
-import { wait } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 
 import SEO from "../SEO";
 
@@ -57,7 +57,7 @@ describe("<SEO />", () => {
       </>
     );
 
-    await wait(() => expect(getMeta("robots")).toEqual("noindex, nofollow"));
+    await waitFor(() => expect(getMeta("robots")).toEqual("noindex, nofollow"));
   });
 });
 ```


### PR DESCRIPTION
Replace deprecated 'wait' with 'waitFor' in 'Testing Document Head Meta Tags'

The use of 'wait' displays a warning:

```
  console.warn
    `wait` has been deprecated and replaced by `waitFor` instead. In most cases you should be able to find/replace `wait` with `waitFor`. Learn more: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.
```